### PR TITLE
Support for f32/f64.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1115,7 +1115,7 @@ fn linkage(lang: &Lang) -> &'static str {
 impl<'a> Generator<'a> {
     fn rust2c_test(&self, ty: &str) -> bool {
         let rustc_types = [
-            "usize", "u8", "u16", "u32", "u64", "isize", "i8", "i16", "i32", "i64",
+            "usize", "u8", "u16", "u32", "u64", "isize", "i8", "i16", "i32", "i64", "f32", "f64",
         ];
         ty.starts_with("c_") || rustc_types.contains(&ty)
     }
@@ -1153,6 +1153,8 @@ impl<'a> Generator<'a> {
             "i16" => "int16_t".to_string(),
             "i32" => "int32_t".to_string(),
             "i64" => "int64_t".to_string(),
+            "f32" => "float".to_string(),
+            "f64" => "double".to_string(),
             "( )" => "void".to_string(),
             s => (self.opts.type_name)(s, self.structs.contains(s), self.unions.contains(s)),
         }

--- a/testcrate/src/t1.c
+++ b/testcrate/src/t1.c
@@ -20,6 +20,9 @@ void T1s(const Arr a) {}
 void T1t(Arr* a) {}
 void T1v(const Arr* a) {}
 
+void T1sf(float f) {}
+void T1df(double d) {}
+
 unsigned T1static = 3;
 
 const uint8_t T1_static_u8 = 42;

--- a/testcrate/src/t1.h
+++ b/testcrate/src/t1.h
@@ -57,6 +57,9 @@ void T1s(const Arr a);
 void T1t(Arr* a);
 void T1v(const Arr* a);
 
+void T1sf(float);
+void T1df(double);
+
 #define T1C 4
 
 extern uint32_t T1static;

--- a/testcrate/src/t1.rs
+++ b/testcrate/src/t1.rs
@@ -80,6 +80,9 @@ extern "C" {
     pub fn T1t(a: *mut *mut Arr);
     pub fn T1v(a: *const *const Arr) -> !;
 
+    pub fn T1sf(f: f32);
+    pub fn T1df(d: f64);
+
     pub static T1static: c_uint;
 }
 


### PR DESCRIPTION
bindgen outputs f32/f64 instead of c_float/c_double now, so let's
support that here.