### PR TITLE
Add ABI roundtrip test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,22 @@ language: rust
 matrix:
   fast_finish: true
   include:
-    - name: "stable"
+    - name: "stable (x86_64-unknown-linux-gnu)"
       rust: stable
-    - name: "beta"
+    - name: "beta (x86_64-unknown-linux-gnu)"
       rust: beta
-    - name: "nightly"
+    - name: "nightly (x86_64-unknown-linux-gnu) + libc-test + tools + docs"
       rust: nightly
-    - name: "master doc to gh-pages"
-      rust: nightly
-      script:
+      after_script:
+        - ci/run-docker.sh x86_64-unknown-linux-gnu
+        - |
+          if rustup component add rustfmt-preview ; then
+              cargo fmt --all -- --check
+          fi
+        - |
+          if rustup component add clippy-preview ; then
+            cargo clippy -- -D clippy::pedantic
+          fi
         - cargo doc --no-deps
       deploy:
         provider: script
@@ -19,8 +26,7 @@ matrix:
         skip_cleanup: true
         on:
           branch: master
-
-    - name: "libc-test (osx)"
+    - name: "nightly (x86_64-apple-darwin) + libc-test"
       rust: nightly
       os: osx
       osx_image: xcode9.4
@@ -32,23 +38,6 @@ matrix:
         - |
           export TARGET=x86_64-apple-darwin
           sh ci/run.sh $TARGET
-    - name: "libc-test (linux)"
-      rust: nightly
-      script: ci/run-docker.sh x86_64-unknown-linux-gnu
-    - name: "rustfmt"
-      install: true
-      rust: nightly
-      script: |
-        if rustup component add rustfmt-preview ; then
-            cargo fmt --all -- --check
-        fi
-    - name: "clippy"
-      install: true
-      rust: nightly
-      script: |
-        if rustup component add clippy-preview ; then
-            cargo clippy -- -D clippy::pedantic
-        fi
 
 script:
   - cargo test

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,8 @@ matrix:
       rust: beta
 
 script:
-  - cargo test
-  - cargo test --manifest-path testcrate/Cargo.toml
+  - cargo test --all
+  - cargo test --all --release
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ language: rust
 matrix:
   fast_finish: true
   include:
-    - name: "stable (x86_64-unknown-linux-gnu)"
-      rust: stable
-    - name: "beta (x86_64-unknown-linux-gnu)"
-      rust: beta
     - name: "nightly (x86_64-unknown-linux-gnu) + libc-test + tools + docs"
       rust: nightly
       after_script:
@@ -38,6 +34,10 @@ matrix:
         - |
           export TARGET=x86_64-apple-darwin
           sh ci/run.sh $TARGET
+    - name: "stable (x86_64-unknown-linux-gnu)"
+      rust: stable
+    - name: "beta (x86_64-unknown-linux-gnu)"
+      rust: beta
 
 script:
   - cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ Automated tests of FFI bindings.
 """
 
 [dependencies]
-syntex_syntax = "0.59.1"
+syntex_syntax2 = "0.0.1"
 cc = "1.0.1"
 rustc_version = "0.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ Automated tests of FFI bindings.
 """
 
 [dependencies]
-syntex_syntax2 = "0.0.1"
+syntex_syntax2 = "0.0.2"
 cc = "1.0.1"
 rustc_version = "0.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctest"
-version = "0.2.14"
+version = "0.2.15"
 authors = [
   "Alex Crichton <alex@alexcrichton.com>",
   "Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,5 +17,5 @@ install:
 build: false
 
 test_script:
-  - cargo test
-  - cargo test --manifest-path testcrate/Cargo.toml
+  - cargo test --all
+  - cargo test --all --release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,19 +1,19 @@
 environment:
   matrix:
   - TARGET: x86_64-pc-windows-gnu
+    ARCH: x86_64
     MSYS_BITS: 64
   - TARGET: i686-pc-windows-gnu
+    ARCH: i686
     MSYS_BITS: 32
   - TARGET: x86_64-pc-windows-msvc
   - TARGET: i686-pc-windows-msvc
 install:
   - if defined MSYS_BITS set PATH=C:\msys64\mingw%MSYS_BITS%\bin;C:\msys64\usr\bin;%PATH%;
-  - if defined MSYS_BITS pacman -U /var/cache/pacman/pkg/mingw-w64-x86_64-crt-git-5.0.0.4745.d2384c2-1-any.pkg.tar.xz
-  - if defined MSYS_BITS pacman -U /var/cache/pacman/pkg/mingw-w64-x86_64-headers-git-5.0.0.4747.0f8f626-1-any.pkg.tar.xz
-  - if defined MSYS_BITS pacman -U /var/cache/pacman/pkg/mingw-w64-x86_64-winpthreads-git-5.0.0.4741.2c8939a-1-any.pkg.tar.xz /var/cache/pacman/pkg/mingw-w64-x86_64-libwinpthread-git-5.0.0.4741.2c8939a-1-any.pkg.tar.xz
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.exe"
   - rust-nightly-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
   - set PATH=%PATH%;C:\Program Files (x86)\Rust\bin
+  - if defined MSYS_BITS for %%I in (crt2.o dllcrt2.o libmsvcrt.a) do xcopy /Y "C:\msys64\mingw%MSYS_BITS%\%ARCH%-w64-mingw32\lib\%%I" "C:\Program Files (x86)\Rust\lib\rustlib\%TARGET%\lib"
   - rustc -V
   - cargo -V
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,10 +7,13 @@ environment:
   - TARGET: x86_64-pc-windows-msvc
   - TARGET: i686-pc-windows-msvc
 install:
+  - if defined MSYS_BITS set PATH=C:\msys64\mingw%MSYS_BITS%\bin;C:\msys64\usr\bin;%PATH%;
+  - if defined MSYS_BITS pacman -U /var/cache/pacman/pkg/mingw-w64-x86_64-crt-git-5.0.0.4745.d2384c2-1-any.pkg.tar.xz
+  - if defined MSYS_BITS pacman -U /var/cache/pacman/pkg/mingw-w64-x86_64-headers-git-5.0.0.4747.0f8f626-1-any.pkg.tar.xz
+  - if defined MSYS_BITS pacman -U /var/cache/pacman/pkg/mingw-w64-x86_64-winpthreads-git-5.0.0.4741.2c8939a-1-any.pkg.tar.xz /var/cache/pacman/pkg/mingw-w64-x86_64-libwinpthread-git-5.0.0.4741.2c8939a-1-any.pkg.tar.xz
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.exe"
   - rust-nightly-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
   - set PATH=%PATH%;C:\Program Files (x86)\Rust\bin
-  - if defined MSYS_BITS set PATH=%PATH%;C:\msys64\mingw%MSYS_BITS%\bin
   - rustc -V
   - cargo -V
 
@@ -18,4 +21,3 @@ build: false
 
 test_script:
   - cargo test --all
-  - cargo test --all --release

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -12,4 +12,4 @@ git clone https://github.com/rust-lang/libc target/libc
 mkdir -p target/libc/target/ctest
 sed -i 's@ctest = "0.2"@ctest = { path = "../../.." }@g' target/libc/libc-test/Cargo.toml
 
-cargo test --manifest-path target/libc/libc-test/Cargo.toml --target $TARGET
+cargo test --release --manifest-path target/libc/libc-test/Cargo.toml --target $TARGET

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1954,8 +1954,8 @@ impl<'a> Generator<'a> {
                       let c = if c == 0 {{ 42 }} else {{ c }};
                       let d: u8 = 255_u8 - (i % 256) as u8;
                       let d = if d == 0 {{ 42 }} else {{ d }};
-                      x_ptr.add(i).write(c);
-                      y_ptr.add(i).write(d);
+                      x_ptr.add(i).write_volatile(c);
+                      y_ptr.add(i).write_volatile(d);
                   }}
                   let r: U = __test_roundtrip_{ty}(x, &mut error, pad.as_ptr());
                   if error == 1 {{
@@ -1966,8 +1966,8 @@ impl<'a> Generator<'a> {
                       if pad[i] == 1 {{ continue; }}
                       // eprintln!("Rusta testing byte {{}} of {{}} of {ty}", i, size_of::<U>());
                       let rust = (*y_ptr.add(i)) as usize;
-                      let c = (&r as *const _ as *const u8).add(i).read()
-                                 as usize;
+                      let c = (&r as *const _ as *const u8)
+                                 .add(i).read_volatile() as usize;
                       if rust != c {{
                         eprintln!(
                             "rust [{{}}] = {{}} != {{}} (C): C \"{ty}\" -> Rust",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 #![deny(missing_docs)]
 
 extern crate cc;
-extern crate syntex_syntax as syntax;
+extern crate syntex_syntax2 as syntax;
 
 extern crate rustc_version;
 
@@ -2052,7 +2052,7 @@ impl<'a, 'v> Visitor<'v> for Generator<'a> {
                 let is_c = i.attrs.iter().any(|a| {
                     attr::find_repr_attrs(self.sh, a)
                         .iter()
-                        .any(|a| *a == ReprAttr::ReprExtern)
+                        .any(|a| *a == ReprAttr::ReprExtern /*|| *a == ReprAttr::ReprTransparent*/)
                 });
                 if !is_c && !(self.opts.skip_struct)(&i.ident.to_string()) {
                     panic!("{} is not marked #[repr(C)]", i.ident);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2052,7 +2052,7 @@ impl<'a, 'v> Visitor<'v> for Generator<'a> {
                 let is_c = i.attrs.iter().any(|a| {
                     attr::find_repr_attrs(self.sh, a)
                         .iter()
-                        .any(|a| *a == ReprAttr::ReprExtern /*|| *a == ReprAttr::ReprTransparent*/)
+                        .any(|a| *a == ReprAttr::ReprExtern || *a == ReprAttr::ReprTransparent)
                 });
                 if !is_c && !(self.opts.skip_struct)(&i.ident.to_string()) {
                     panic!("{} is not marked #[repr(C)]", i.ident);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1817,7 +1817,7 @@ impl<'a> Generator<'a> {
                 fn roundtrip_padding_{ty}() -> Vec<u8> {{
                   // stores (offset, size) for each field
                   let mut v = Vec::<(usize, usize)>::new();
-                  let foo = mem::MaybeUninit::<{ty}>::uninit();
+                  let foo: {} = unsafe {{ std::mem::uninitialized() }};
                   let foo = &foo as *const _ as *const {ty};
                "#,
             ty = rust
@@ -1933,7 +1933,7 @@ impl<'a> Generator<'a> {
             #[inline(never)]
             fn roundtrip_{ty}() {{
                 use libc::c_int;
-                type U = std::mem::MaybeUninit<{ty}>;
+                type U = {ty};
                 #[allow(improper_ctypes)]
                 extern {{
                     #[allow(non_snake_case)]

--- a/testcrate/build.rs
+++ b/testcrate/build.rs
@@ -28,6 +28,7 @@ fn main() {
         })
         .volatile_item(t1_volatile)
         .array_arg(t1_arrays)
+        .skip_roundtrip(|n| n == "Arr")
         .generate("src/t1.rs", "t1gen.rs");
     ctest::TestGenerator::new()
         .header("t2.h")
@@ -38,6 +39,7 @@ fn main() {
             t if is_union => format!("union {}", t),
             t => t.to_string(),
         })
+        .skip_roundtrip(|_| true)
         .generate("src/t2.rs", "t2gen.rs");
 
     ctest::TestGenerator::new()
@@ -54,6 +56,7 @@ fn main() {
         })
         .volatile_item(t1_volatile)
         .array_arg(t1_arrays)
+        .skip_roundtrip(|n| n == "Arr")
         .generate("src/t1.rs", "t1gen_cxx.rs");
     ctest::TestGenerator::new()
         .header("t2.h")
@@ -65,6 +68,7 @@ fn main() {
             t if is_union => format!("union {}", t),
             t => t.to_string(),
         })
+        .skip_roundtrip(|_| true)
         .generate("src/t2.rs", "t2gen_cxx.rs");
 }
 

--- a/testcrate/build.rs
+++ b/testcrate/build.rs
@@ -21,6 +21,7 @@ fn main() {
         .fn_cname(|a, b| b.unwrap_or(a).to_string())
         .type_name(move |ty, is_struct, is_union| match ty {
             "T1Union" => ty.to_string(),
+            "Transparent" => ty.to_string(),
             t if is_struct => format!("struct {}", t),
             t if is_union => format!("union {}", t),
             t => t.to_string(),
@@ -46,6 +47,7 @@ fn main() {
         .fn_cname(|a, b| b.unwrap_or(a).to_string())
         .type_name(move |ty, is_struct, is_union| match ty {
             "T1Union" => ty.to_string(),
+            "Transparent" => ty.to_string(),
             t if is_struct => format!("struct {}", t),
             t if is_union => format!("union {}", t),
             t => t.to_string(),

--- a/testcrate/build.rs
+++ b/testcrate/build.rs
@@ -2,6 +2,15 @@ extern crate cc;
 extern crate ctest;
 
 fn main() {
+    use std::env;
+    let opt_level = env::var("OPT_LEVEL")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    let profile = env::var("PROFILE").unwrap_or(String::new());
+    if profile == "release" || opt_level >= 2 {
+        println!("cargo:rustc-cfg=optimized");
+    }
     cc::Build::new()
         .include("src")
         .warnings(false)

--- a/testcrate/src/t1.c
+++ b/testcrate/src/t1.c
@@ -25,7 +25,6 @@ unsigned T1static = 3;
 const uint8_t T1_static_u8 = 42;
 uint8_t T1_static_mut_u8 = 37;
 
-
 uint8_t foo(uint8_t a, uint8_t b) { return a + b; }
 void bar(uint8_t a) { return; }
 void baz(void) { return; }

--- a/testcrate/src/t1.h
+++ b/testcrate/src/t1.h
@@ -130,6 +130,15 @@ struct Pack {
 
 # pragma pack(pop)
 
+# pragma pack(push,2)
+
+struct Pack2 {
+  uint8_t a;
+  uint32_t b;
+};
+
+# pragma pack(pop)
+
 // volatile pointers in struct fields:
 struct V {
   volatile uint8_t* v;

--- a/testcrate/src/t1.h
+++ b/testcrate/src/t1.h
@@ -133,7 +133,7 @@ struct Pack {
 
 # pragma pack(push,4)
 
-struct Pack2 {
+struct Pack4 {
   uint8_t a;
   uint32_t b;
 };

--- a/testcrate/src/t1.h
+++ b/testcrate/src/t1.h
@@ -131,7 +131,7 @@ struct Pack {
 
 # pragma pack(pop)
 
-# pragma pack(push,2)
+# pragma pack(push,4)
 
 struct Pack2 {
   uint8_t a;

--- a/testcrate/src/t1.h
+++ b/testcrate/src/t1.h
@@ -51,6 +51,7 @@ void T1o(int32_t (*a)[4]);
 void T1p(int32_t (*const a)[4]);
 
 typedef int32_t (Arr)[4];
+typedef int32_t Transparent;
 
 void T1r(Arr a);
 void T1s(const Arr a);

--- a/testcrate/src/t1.rs
+++ b/testcrate/src/t1.rs
@@ -46,8 +46,8 @@ pub struct T1StructWithUnion {
     pub u: T1NoTypedefUnion,
 }
 
-// #[repr(transparent)]
-// pub struct Transparent(i32);
+#[repr(transparent)]
+pub struct Transparent(i32);
 
 pub type T1TypedefDouble = c_double;
 pub type T1TypedefPtr = *mut c_int;

--- a/testcrate/src/t1.rs
+++ b/testcrate/src/t1.rs
@@ -159,7 +159,7 @@ pub struct Pack {
     pub b: u16,
 }
 
-#[repr(C, packed(2))]
+#[repr(C, packed(4))]
 pub struct Pack2 {
     pub a: u8,
     pub b: u32,

--- a/testcrate/src/t1.rs
+++ b/testcrate/src/t1.rs
@@ -46,6 +46,9 @@ pub struct T1StructWithUnion {
     pub u: T1NoTypedefUnion,
 }
 
+// #[repr(transparent)]
+// pub struct Transparent(i32);
+
 pub type T1TypedefDouble = c_double;
 pub type T1TypedefPtr = *mut c_int;
 pub type T1TypedefStruct = T1Bar;
@@ -154,6 +157,12 @@ pub struct T1_conflict {
 pub struct Pack {
     pub a: u8,
     pub b: u16,
+}
+
+#[repr(C, packed(2))]
+pub struct Pack2 {
+    pub a: u8,
+    pub b: u32,
 }
 
 #[repr(C)]

--- a/testcrate/src/t1.rs
+++ b/testcrate/src/t1.rs
@@ -160,7 +160,7 @@ pub struct Pack {
 }
 
 #[repr(C, packed(4))]
-pub struct Pack2 {
+pub struct Pack4 {
     pub a: u8,
     pub b: u32,
 }

--- a/testcrate/tests/all.rs
+++ b/testcrate/tests/all.rs
@@ -65,6 +65,7 @@ fn t2() {
         bad = true;
     }
     if bad {
+        println!("output was:\n\n{}", o);
         panic!();
     }
 }
@@ -108,6 +109,7 @@ fn t2_cxx() {
         bad = true;
     }
     if bad {
+        println!("output was:\n\n{}", o);
         panic!();
     }
 }

--- a/testcrate/tests/all.rs
+++ b/testcrate/tests/all.rs
@@ -17,6 +17,7 @@ fn t1() {
     let (o, status) = output(&mut cmd("t1"));
     assert!(status.success(), o);
     assert!(!o.contains("bad "), o);
+    eprintln!("o: {}", o);
 }
 
 #[test]


### PR DESCRIPTION
r? @alexcrichton 

I've ran into a problem where the Rust type and the C type have the same size, alignment, etc. but they were passed using different ABIs, resulting in garbage [0]. Ctest did not catch that.

I've added a "roundtrip" test that initializes the type with a sequence of bytes, passes the type by value to C to exercise the argument part of the ABI, then C reads it, verifies the bytes, write some other bytes to it, returns it by value back to Rust exercising the return part of the ABI, which verifies it again. 

This test won't detect all cases in which the "call ABI" differs. For example, if the call ABI in Rust is SCALAR but in C it is AGGREGATE, it might happen that the C aggregate ends up using the exact same registers than the Rust scalar. Arguably, if this is the case, the ABI is in practice the same. This test won't catch that.

This implementation has UB because it writes (potentially) invalid bit-pattern to the values. The fix here will be to use `MaybeUninit<T>` once it becomes stable and `repr(transparent)`, since it will have the same ABI as T, but would allow us to never really construct an invalid T. (cc @RalfJ ). We could also just use an `union` here without `#[repr(transparent)]`, because even though it is not guaranteed, unions with one field have the same ABI as the field. (cc @eddyb)

I don't think adding to many workarounds to try to avoid UB here is worth it, particularly because we are already invoking UB in other places (e.g. creating references to packed struct fields and such).

---

@alexcrichton this might break libc CI in a couple of places where we might need to fix an ABI, or skip a test. Once this lands, i'll skip all the failures in libc quickly, and merge that. And then slowly work towards fixing those. 

---

[0]: the problematic types were: `__m128` in the C side, and `#[repr(C, align(16))] struct __m128(i32, i32, i32, i32);` in the Rust side.