### PR TITLE
Optionally generate a "C"-like header with imported items

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1176,10 +1176,10 @@ impl<'a> Generator<'a> {
     fn rust2c(&self, ty: &str) -> String {
         match ty {
             t if t.starts_with("c_") => match &ty[2..].replace("long", " long")[..] {
-                s if s.starts_with('u') => format!("unsigned {}", &s[1..]),
+                s if s.starts_with('u') => format!("unsigned {}", &s[1..].trim()),
                 "short" => "short".to_string(),
-                s if s.starts_with('s') => format!("signed {}", &s[1..]),
-                s => s.to_string(),
+                s if s.starts_with('s') => format!("signed {}", &s[1..].trim()),
+                s => s.trim().to_string(),
             },
 
             "usize" => "size_t".to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,33 @@ pub enum VolatileItemKind {
     __Other,
 }
 
+/// API item imported from C
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+enum ApiItem {
+    Function {
+        name: String,
+        return_type: String,
+        arguments: String,
+    },
+    Static {
+        name: String,
+        type_: String,
+    },
+}
+
+impl std::fmt::Display for ApiItem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Function {
+                name,
+                return_type,
+                arguments,
+            } => write!(f, "{} {}({});", return_type, name, arguments),
+            Self::Static { name, type_ } => write!(f, "extern {} {};", type_, name),
+        }
+    }
+}
+
 /// A builder used to generate a test suite.
 ///
 /// This builder has a number of configuration options which modify how the
@@ -90,6 +117,7 @@ pub struct TestGenerator {
     flags: Vec<String>,
     target: Option<String>,
     out_dir: Option<PathBuf>,
+    out_items: Option<String>,
     defines: Vec<(String, Option<String>)>,
     cfg: Vec<(String, Option<String>)>,
     verbose_skip: bool,
@@ -131,6 +159,7 @@ struct Generator<'a> {
     abi: Abi,
     tests: Vec<String>,
     sess: &'a ParseSess,
+    items: Vec<Box<ApiItem>>,
     opts: &'a TestGenerator,
 }
 
@@ -147,6 +176,7 @@ impl TestGenerator {
             flags: Vec::new(),
             target: None,
             out_dir: None,
+            out_items: None,
             defines: Vec::new(),
             cfg: Vec::new(),
             verbose_skip: false,
@@ -504,6 +534,27 @@ impl TestGenerator {
         F: Fn(&str) -> String + 'static,
     {
         self.const_cname = Box::new(f);
+        self
+    }
+
+    /// Store found API items in given file (prefixed by out_dir)
+    ///
+    /// The export should use C-like syntax and use deterministic order, but is
+    /// not guaranteed to be stable.  It is designed to give humans a quick list
+    /// and a way to track the changes.
+    ///
+    /// Right now only extern functions and ("static") variables are listed.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use ctest::TestGenerator;
+    ///
+    /// let mut cfg = TestGenerator::new();
+    /// cfg.out_items("items.h");
+    /// ```
+    pub fn out_items(&mut self, filename: &str) -> &mut Self {
+        self.out_items = Some(filename.to_string());
         self
     }
 
@@ -961,6 +1012,7 @@ impl TestGenerator {
             tests: Vec::new(),
             files: HashSet::new(),
             sess: &sess,
+            items: Vec::new(),
             opts: self,
         };
         t!(writeln!(gen.c, "#include <stdio.h>"));
@@ -1045,6 +1097,15 @@ impl TestGenerator {
         // Walk the crate, emitting test cases for everything found
         visit::walk_crate(&mut gen, &krate);
         gen.emit_run_all();
+
+        if let Some(out_items) = &self.out_items {
+            let out_items = out_dir.join(out_items);
+            let mut items_out = BufWriter::new(t!(File::create(&out_items)));
+            gen.items.sort();
+            for i in &gen.items {
+                t!(writeln!(items_out, "{}", i));
+            }
+        }
 
         if self.abort_on_errors {
             sess.span_diagnostic.abort_if_errors();
@@ -1615,6 +1676,19 @@ impl<'a> Generator<'a> {
             c_ret = format!("volatile {}", c_ret);
         }
         let abi = self.abi2str(abi);
+
+        if self.opts.out_items.is_some() {
+            self.items.push(Box::new(ApiItem::Function {
+                name: name.to_string(),
+                return_type: if abi.is_empty() {
+                    ret.to_string()
+                } else {
+                    format!("{} {}", ret, abi)
+                },
+                arguments: args.to_string(),
+            }));
+        }
+
         t!(writeln!(
             self.c,
             r#"
@@ -1673,6 +1747,13 @@ impl<'a> Generator<'a> {
         }
 
         let c_name = c_name.unwrap_or_else(|| name.to_string());
+
+        if self.opts.out_items.is_some() {
+            self.items.push(Box::new(ApiItem::Static {
+                name: c_name.to_string(),
+                type_: c_ty.to_string(),
+            }));
+        }
 
         if rust_ty.contains("extern fn") {
             let sig = c_ty.replacen("(*)", &format!("(* __test_static_{}(void))", name), 1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -498,6 +498,7 @@ impl TestGenerator {
     /// cfg.const_cname(|c| {
     ///     c.replace("FOO", "foo")
     /// });
+    /// ```
     pub fn const_cname<F>(&mut self, f: F) -> &mut Self
     where
         F: Fn(&str) -> String + 'static,

--- a/testcrate/src/t1.h
+++ b/testcrate/src/t1.h
@@ -62,24 +62,24 @@ void T1v(const Arr* a);
 
 extern uint32_t T1static;
 extern const uint8_t T1_static_u8;
-uint8_t T1_static_mut_u8;
-uint8_t (*T1_static_mut_fn_ptr)(uint8_t, uint8_t);
+extern uint8_t T1_static_mut_u8;
+extern uint8_t (*T1_static_mut_fn_ptr)(uint8_t, uint8_t);
 extern uint8_t (*const T1_static_const_fn_ptr_unsafe)(uint8_t, uint8_t);
 extern void (*const T1_static_const_fn_ptr_unsafe2)(uint8_t);
 extern void (*const T1_static_const_fn_ptr_unsafe3)(void);
 
 extern const uint8_t T1_static_right;
-uint8_t (*T1_static_right2)(uint8_t, uint8_t);
+extern uint8_t (*T1_static_right2)(uint8_t, uint8_t);
 
 // T1_fn_ptr_nested: function pointer to a function, taking a uint8_t, and
 // returning a function pointer to a function taking a uint16_t and returning a
 // uint32_t
-uint32_t (*(*T1_fn_ptr_s)(uint8_t))(uint16_t);
+extern uint32_t (*(*T1_fn_ptr_s)(uint8_t))(uint16_t);
 
 // T1_fn_ptr_nested: function pointer to a function, taking a function pointer
 // uint8_t -> uint8_t, and returning a function pointer to a function taking a
 // uint16_t and returning a uint32_t
-uint32_t (*(*T1_fn_ptr_s2)(uint8_t(*)(uint8_t), uint16_t(*)(uint16_t)))(uint16_t);
+extern uint32_t (*(*T1_fn_ptr_s2)(uint8_t(*)(uint8_t), uint16_t(*)(uint16_t)))(uint16_t);
 
 extern const int32_t T1_arr0[2];
 extern const int32_t T1_arr1[2][3];
@@ -98,8 +98,8 @@ extern int32_t* T1_mut_opt_mut_ref;
 extern const int32_t* T1_const_opt_const_ref;
 
 extern void (*const T1_opt_fn1)(void);
-uint32_t (*(*T1_opt_fn2)(uint8_t))(uint16_t);
-uint32_t (*(*T1_opt_fn3)(uint8_t(*)(uint8_t), uint16_t(*)(uint16_t)))(uint16_t);
+extern uint32_t (*(*T1_opt_fn2)(uint8_t))(uint16_t);
+extern uint32_t (*(*T1_opt_fn3)(uint8_t(*)(uint8_t), uint16_t(*)(uint16_t)))(uint16_t);
 
 
 struct Q {
@@ -154,7 +154,7 @@ volatile void* T1_vol1(void*, void*);
 volatile void* T1_vol2(void*, volatile void*);
 
 // volatile function pointers:
-uint8_t (*volatile T1_fn_ptr_vol)(uint8_t, uint8_t);
+extern uint8_t (*volatile T1_fn_ptr_vol)(uint8_t, uint8_t);
 
 #define LOG_MAX_LINE_LENGTH (1400)
 


### PR DESCRIPTION
While adding various bindings and now trying to refactor defining those with macros in [`openssl-sys`](https://github.com/sfackler/rust-openssl/tree/master/openssl-sys) I wanted to check what functions I ended up importing (and their expected "C type"), and whether I lost or broke something.

With this a separate C-like file can be generated in `build.rs` (`.out_items("items.h")`) and e.g. printed in a separate binary with:

```rust
fn main() {
    print!("{}", include_str!(concat!(env!("OUT_DIR"), "/items.h")));
}
```

This is mostly for debugging / "human" tracking of changes, so I don't see a need to test this.

I also hit a few other minor issues and added fixes, although they all should be independent.